### PR TITLE
Use ssh-config to execute ssh faster

### DIFF
--- a/wocker
+++ b/wocker
@@ -32,9 +32,12 @@ case "$1" in
 
     if [[ "$2" && ! "$2" =~ ^-.*$ ]]; then
       WOCKER_COMMAND="wocker start $2"
-      vagrant $1 && vagrant_ssh "${WOCKER_COMMAND}"
+      vagrant $1
+      vagrant ssh-config > "${SSH_CONFIG}"
+      vagrant_ssh "${WOCKER_COMMAND}"
     else
       vagrant $@
+      vagrant ssh-config > "${SSH_CONFIG}"
     fi
     ;;
 
@@ -45,9 +48,13 @@ case "$1" in
 
     if [[ "$2" && ! "$2" =~ ^-.*$ ]]; then
       WOCKER_COMMAND="wocker start $2"
-      vagrant_ssh "wocker stop" && vagrant $1 && vagrant_ssh "${WOCKER_COMMAND}"
+      vagrant_ssh "wocker stop"
+      vagrant $1
+      vagrant ssh-config > "${SSH_CONFIG}"
+      vagrant_ssh "${WOCKER_COMMAND}"
     else
       vagrant $@
+      vagrant ssh-config > "${SSH_CONFIG}"
     fi
     ;;
 
@@ -55,13 +62,14 @@ case "$1" in
   # Stop all containers before `vagrant halt`
   #
   'halt' )
-    vagrant_ssh "wocker stop" && vagrant $1
+    vagrant_ssh "wocker stop"
+    vagrant $1
     ;;
 
   #
   # Commonly used vagrant commands
   #
-  'up' | 'ssh' | 'halt' | 'status' | 'reload' | 'resume' | 'suspend' )
+  'ssh' | 'status' | 'resume' | 'suspend' )
     vagrant $@
     ;;
 

--- a/wocker
+++ b/wocker
@@ -49,17 +49,9 @@ case "$1" in
     ;;
 
   #
-  # Docker command aliases
+  # Docker command aliases, Wocker original commands and others just pass through
   #
-  'daemon' | 'attach' | 'build' | 'commit' | 'cp' | 'create' | 'diff' | 'events' | 'exec' | 'export' | 'history' | 'images' | 'import' | 'info' | 'inspect' | 'kill' | 'load' | 'login' | 'logout' | 'logs' | 'network connect' | 'network create' | 'network disconnect' | 'network inspect' | 'network ls' | 'network rm' | 'pause' | 'port' | 'ps' | 'pull' | 'push' | 'rename' | 'restart' | 'rm' | 'rmi' | 'run' | 'save' | 'search' | 'start' | 'stats' | 'stop' | 'tag' | 'top' | 'unpause' | 'version' | 'volume create' | 'volume inspect' | 'volume ls' | 'volume rm' | 'wait' )
-    WOCKER_COMMAND="wocker $@"
-    vagrant_ssh "${WOCKER_COMMAND}"
-    ;;
-
-  #
-  # Wocker original commands
-  #
-  'destroy' | 'help' | '--help' | '-h' | 'switch' | 'update' | '--version' | '-v' | 'wp' )
+  * )
     WOCKER_COMMAND="wocker $@"
     vagrant_ssh "${WOCKER_COMMAND}"
     ;;

--- a/wocker
+++ b/wocker
@@ -16,7 +16,11 @@ vagrant_ssh() {
   if [ ! -e "${SSH_CONFIG}" ]; then
     vagrant ssh-config > "${SSH_CONFIG}"
   fi
-  ssh -F "${SSH_CONFIG}" wocker "bash -lc '$*'"
+  if grep -q "^Host wocker" "${SSH_CONFIG}"; then
+    ssh -F "${SSH_CONFIG}" wocker "bash -lc '$*'"
+  else
+    rm -f "${SSH_CONFIG}"
+  fi
 }
 
 case "$1" in

--- a/wocker
+++ b/wocker
@@ -12,12 +12,14 @@ SSH_CONFIG="${DIR}/.ssh_config"
 
 cd ${PWD}
 
-vagrant_ssh() {
+wocker_cli() {
   trap "rm -f '${SSH_CONFIG}'" ERR
   if [ ! -e "${SSH_CONFIG}" ]; then
     vagrant ssh-config > "${SSH_CONFIG}"
   fi
-  ssh -F "${SSH_CONFIG}" wocker "bash -lc '$*'"
+  ssh -F "${SSH_CONFIG}" wocker "bash -l" <<EOT
+wocker "$@"
+EOT
 }
 
 case "$1" in
@@ -28,12 +30,11 @@ case "$1" in
   'up' )
 
     if [[ "$2" && ! "$2" =~ ^-.*$ ]]; then
-      WOCKER_COMMAND="wocker start $2"
       vagrant $1
       vagrant ssh-config > "${SSH_CONFIG}"
-      vagrant_ssh "${WOCKER_COMMAND}"
+      wocker_cli start "$2"
     else
-      vagrant $@
+      vagrant "$@"
       vagrant ssh-config > "${SSH_CONFIG}"
     fi
     ;;
@@ -44,13 +45,12 @@ case "$1" in
   'reload' )
 
     if [[ "$2" && ! "$2" =~ ^-.*$ ]]; then
-      WOCKER_COMMAND="wocker start $2"
-      vagrant_ssh "wocker stop"
+      wocker_cli stop
       vagrant $1
       vagrant ssh-config > "${SSH_CONFIG}"
-      vagrant_ssh "${WOCKER_COMMAND}"
+      wocker_cli start "$2"
     else
-      vagrant $@
+      vagrant "$@"
       vagrant ssh-config > "${SSH_CONFIG}"
     fi
     ;;
@@ -59,7 +59,7 @@ case "$1" in
   # Stop all containers before `vagrant halt`
   #
   'halt' )
-    vagrant_ssh "wocker stop"
+    wocker_cli stop
     vagrant $1
     ;;
 
@@ -67,15 +67,14 @@ case "$1" in
   # Commonly used vagrant commands
   #
   'ssh' | 'status' | 'resume' | 'suspend' )
-    vagrant $@
+    vagrant "$@"
     ;;
 
   #
   # Docker command aliases, Wocker original commands and others just pass through
   #
   * )
-    WOCKER_COMMAND="wocker $@"
-    vagrant_ssh "${WOCKER_COMMAND}"
+    wocker_cli "$@"
     ;;
 
 esac

--- a/wocker
+++ b/wocker
@@ -1,3 +1,11 @@
+vagrant_ssh() {
+  SSH_CONFIG=".ssh_config"
+  if [ ! -e "${SSH_CONFIG}" ]; then
+    vagrant ssh-config > "${SSH_CONFIG}"
+  fi
+  ssh -F "${SSH_CONFIG}" wocker "bash -lc '$*'"
+}
+
 case "$1" in
 
   #
@@ -7,7 +15,7 @@ case "$1" in
 
     if [[ "$2" && ! "$2" =~ ^-.*$ ]]; then
       WOCKER_COMMAND="wocker start $2"
-      vagrant $1 && vagrant ssh -c "${WOCKER_COMMAND}"
+      vagrant $1 && vagrant_ssh "${WOCKER_COMMAND}"
     else
       vagrant $@
     fi
@@ -20,7 +28,7 @@ case "$1" in
 
     if [[ "$2" && ! "$2" =~ ^-.*$ ]]; then
       WOCKER_COMMAND="wocker start $2"
-      vagrant ssh -c "wocker stop" && vagrant $1 && vagrant ssh -c "${WOCKER_COMMAND}"
+      vagrant_ssh "wocker stop" && vagrant $1 && vagrant_ssh "${WOCKER_COMMAND}"
     else
       vagrant $@
     fi
@@ -30,7 +38,7 @@ case "$1" in
   # Stop all containers before `vagrant halt`
   #
   'halt' )
-    vagrant ssh -c "wocker stop" && vagrant $1
+    vagrant_ssh "wocker stop" && vagrant $1
     ;;
 
   #
@@ -45,7 +53,7 @@ case "$1" in
   #
   'daemon' | 'attach' | 'build' | 'commit' | 'cp' | 'create' | 'diff' | 'events' | 'exec' | 'export' | 'history' | 'images' | 'import' | 'info' | 'inspect' | 'kill' | 'load' | 'login' | 'logout' | 'logs' | 'network connect' | 'network create' | 'network disconnect' | 'network inspect' | 'network ls' | 'network rm' | 'pause' | 'port' | 'ps' | 'pull' | 'push' | 'rename' | 'restart' | 'rm' | 'rmi' | 'run' | 'save' | 'search' | 'start' | 'stats' | 'stop' | 'tag' | 'top' | 'unpause' | 'version' | 'volume create' | 'volume inspect' | 'volume ls' | 'volume rm' | 'wait' )
     WOCKER_COMMAND="wocker $@"
-    vagrant ssh -c "${WOCKER_COMMAND}"
+    vagrant_ssh "${WOCKER_COMMAND}"
     ;;
 
   #
@@ -53,7 +61,7 @@ case "$1" in
   #
   'destroy' | 'help' | '--help' | '-h' | 'switch' | 'update' | '--version' | '-v' | 'wp' )
     WOCKER_COMMAND="wocker $@"
-    vagrant ssh -c "${WOCKER_COMMAND}"
+    vagrant_ssh "${WOCKER_COMMAND}"
     ;;
 
 esac

--- a/wocker
+++ b/wocker
@@ -1,5 +1,18 @@
+#!/bin/sh
+set -e
+
+PWD=$(pwd)
+
+DIR=$(pwd)
+while [ "${DIR}" != "/" -a ! -e "${DIR}/Vagrantfile" ]; do
+  cd ..
+  DIR=$(pwd)
+done
+SSH_CONFIG="${DIR}/.ssh_config"
+
+cd ${PWD}
+
 vagrant_ssh() {
-  SSH_CONFIG=".ssh_config"
   if [ ! -e "${SSH_CONFIG}" ]; then
     vagrant ssh-config > "${SSH_CONFIG}"
   fi

--- a/wocker
+++ b/wocker
@@ -17,9 +17,7 @@ wocker_cli() {
   if [ ! -e "${SSH_CONFIG}" ]; then
     vagrant ssh-config > "${SSH_CONFIG}"
   fi
-  ssh -F "${SSH_CONFIG}" wocker "bash -l" <<EOT
-wocker "$@"
-EOT
+  echo wocker "$@" | ssh -F "${SSH_CONFIG}" wocker "bash -l"
 }
 
 case "$1" in

--- a/wocker
+++ b/wocker
@@ -17,6 +17,8 @@ wocker_cli() {
   if [ ! -e "${SSH_CONFIG}" ]; then
     vagrant ssh-config > "${SSH_CONFIG}"
   fi
+  ssh -F "${SSH_CONFIG}" wocker exit
+  trap "" ERR
   echo wocker "$@" | ssh -F "${SSH_CONFIG}" wocker "bash -l"
 }
 

--- a/wocker
+++ b/wocker
@@ -13,14 +13,11 @@ SSH_CONFIG="${DIR}/.ssh_config"
 cd ${PWD}
 
 vagrant_ssh() {
+  trap "rm -f '${SSH_CONFIG}'" ERR
   if [ ! -e "${SSH_CONFIG}" ]; then
     vagrant ssh-config > "${SSH_CONFIG}"
   fi
-  if grep -q "^Host wocker" "${SSH_CONFIG}"; then
-    ssh -F "${SSH_CONFIG}" wocker "bash -lc '$*'"
-  else
-    rm -f "${SSH_CONFIG}"
-  fi
+  ssh -F "${SSH_CONFIG}" wocker "bash -lc '$*'"
 }
 
 case "$1" in


### PR DESCRIPTION
and, other commands just pass through and should be evaluated by wocker-cli at the VM side.

And also I found a bug at the case of 'network' and 'volume' subcommands in wocker-cli at the VM.
`'network connect' | 'network create' | 'network disconnect' | 'network inspect' | 'network ls' | 'network rm'` should be `'network'`
and
`'volume create' | 'volume inspect' | 'volume ls' | 'volume rm'` should be `'volume'`.
